### PR TITLE
Add suport for mongo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-node_modules


### PR DESCRIPTION
I've added some quick support to use jasper with Mongodb, as Mongodb doesn't support jdbc directly.
You'll need to get js-mongodb-datasource-x.x.x.jar and mongo-java-driver-x.x.x.jar from the JasperSoft Studio though.
