### PR TITLE
Multiple reports print error

### DIFF
--- a/index.js
+++ b/index.js
@@ -207,7 +207,7 @@ jasper.prototype.export = function(report, type) {
 		} else if(util.isArray(report)) {
 			var ret = [];
 			report.forEach(function(i) {
-				ret.concat(processReport(i));
+				ret = ret.concat(processReport(i));
 			});
 			return ret;
 		} else if(typeof report == 'function') {


### PR DESCRIPTION
It seems that there is an error on the function that iterates over the reports definitions.
The javascript concat function not modifies the arrays, so the returned value should be assigned to "ret" array.