### PR TITLE
Fix: On multiple reports, the data and dataset are overriden when hav…

### DIFF
--- a/index.js
+++ b/index.js
@@ -203,7 +203,7 @@ jasper.prototype.export = function(report, type) {
 
 	var processReport = function(report) {
 		if(typeof report == 'string') {
-			return [self.reports[report]];
+			return [extend({},self.reports[report])];
 		} else if(util.isArray(report)) {
 			var ret = [];
 			report.forEach(function(i) {
@@ -214,7 +214,6 @@ jasper.prototype.export = function(report, type) {
 			return processReport(report());
 		} else if(typeof report == 'object') {
 			if(report.data||report.override) {
-				var ret = [];
 				var reps = processReport(report.report);
 				return reps.map(function(i) {
 					if(report.override) {


### PR DESCRIPTION
…e same definition

If you want to print an array of reports with the same definition (same report name), line 206 was referencing instead of copying the definition. So, you are modifying the data and dataset properties (line 222 and 223) for all and getting the last values of the last element of the loop (line 209). 

It is necessary to copy the definition and not get a reference.