### PR TITLE
feat: add support for REPORT_LOCALE parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,6 +160,7 @@ function jasper(options) {
 			self.hm = java.import('java.util.HashMap');
 			self.jfm = java.import('net.sf.jasperreports.engine.JasperFillManager');
 			self.jem = java.import('net.sf.jasperreports.engine.JasperExportManager');
+			self.loc = java.import('java.util.Locale');
 
 			cb();
 		}]
@@ -274,6 +275,17 @@ jasper.prototype.export = function(report, type) {
 
 	};
 
+	var parseLocale = function (localeString) {
+		var tokens = localeString.split(/[_|-]/);
+
+		if (tokens.length > 1) {
+			return self.loc(tokens[0], tokens[1]);
+		}
+		else {
+			return self.loc(tokens[0]);
+		}
+	}
+
 	var reports = processReport(report);
 	var prints = [];
 	reports.forEach(function(item) {
@@ -293,6 +305,9 @@ jasper.prototype.export = function(report, type) {
 			if(item.data) {
 				data = new self.hm();
 				for(var j in item.data) {
+					if (j === 'REPORT_LOCALE') {
+						item.data[j] = parseLocale(item.data[j]);
+					}
 					data.putSync(j, item.data[j])
 				}
 			}


### PR DESCRIPTION
You can set the 'REPORT_LOCALE' by passing a parameter named 'REPORT_LOCALE' in the report 'data' property with a locale string like 'pt_PT' or just 'fr'.

#11